### PR TITLE
bump broom version in test

### DIFF
--- a/tests/testthat/test-asymmetrise_stats.R
+++ b/tests/testthat/test-asymmetrise_stats.R
@@ -9,7 +9,7 @@ test_that("stats asymmetrization works", {
                           val = rnorm(n_reps * length(grps)))
     tukey <- TukeyHSD(aov(val ~ grp, data = tib))
 
-    if (utils::packageVersion("broom") > 0.6) {
+    if (utils::packageVersion("broom") > 0.7) {
         expect_error(prepare_data(grps),
                      "Could not handle input data; try turning into a tibble using the broom package")
     } else {


### PR DESCRIPTION
Hey there!

We were recently asked by the CRAN team to revert the deprecation of the character vector tidiers in preparation for the release of [broom 0.7.0](https://github.com/tidymodels/broom/tree/0.7.0-rc), so calling them will once again result in a warning rather than an error. Unfortunately, this means that your package will once again be broken by broom 0.7.0. Assuming you want to keep testing this result, since we plan to move forward with the deprecation of the character vector tidiers in the release following 0.7.0, I've bumped the `if` condition to expect an error after 0.7.0, but to continue to expect a warning in 0.7.0. I apologize for the conflicting messaging.

Much appreciated!