### PR TITLE
not keeping out.attrs. Related to dplyr 1.0.6

### DIFF
--- a/R/asymmetrise.R
+++ b/R/asymmetrise.R
@@ -228,7 +228,7 @@ bind_missing_combs <- function(df, .x, .y)  {
 get_other_combs <- function(x, y) {
     current_combs <- paste(x, y, sep = "_")
     all_vals <- unique(c(x, y))
-    all_combs <- expand.grid(all_vals, all_vals, stringsAsFactors = FALSE) %>%
+    all_combs <- expand.grid(all_vals, all_vals, stringsAsFactors = FALSE, KEEP.OUT.ATTRS = FALSE) %>%
         unique() %>%
         dplyr::mutate(comb = paste(Var1, Var2, sep = "_")) %>%
         dplyr::filter(!(comb %in% current_combs)) %>%


### PR DESCRIPTION
in `dplyr` 1.0.6 which we are about to release, the attributes are kept after a `select()`. Unfortunately, this breaks some of your tests. 

This pull request calls `expand.grid()` with `KEEP.OUT.ATTRS = FALSE` so that these attributes are not generated to beging with. This should work with both cran version of `dplyr` and the release candidate. 

Alternatively, I would suggest to switch to the 3rd edition of `testthat` where you can `expect_equal(ignore_attr = TRUE)` thanks to the `waldo` package. See https://testthat.r-lib.org/articles/third-edition.html for more details. 